### PR TITLE
Remove IP prevention after defined time in minutes.

### DIFF
--- a/src/ServerBaseHandler.php
+++ b/src/ServerBaseHandler.php
@@ -32,33 +32,12 @@ class ServerBaseHandler extends WebSocket
             'WsServer_model',
         ]);
     }
-
-
-    private function get_client_ip() {
-        $ipaddress = '';
-        if (isset($_SERVER['HTTP_CLIENT_IP']))
-            $ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-        else if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-            $ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
-        else if(isset($_SERVER['HTTP_X_FORWARDED']))
-            $ipaddress = $_SERVER['HTTP_X_FORWARDED'];
-        else if(isset($_SERVER['HTTP_FORWARDED_FOR']))
-            $ipaddress = $_SERVER['HTTP_FORWARDED_FOR'];
-        else if(isset($_SERVER['HTTP_FORWARDED']))
-            $ipaddress = $_SERVER['HTTP_FORWARDED'];
-        else if(isset($_SERVER['REMOTE_ADDR']))
-            $ipaddress = $_SERVER['REMOTE_ADDR'];
-        else
-            $ipaddress = 'UNKNOWN';
-        return $ipaddress;
-    }
-
-
+    
     public function onOpen(ConnectionContract $conn)
     {
         $connId = $conn->getUniqueSocketId();
         $this->clients[$connId] = $conn;
-        $this->log->debug("Connection opend, IP : ". $this->get_client_ip() ." Conn ID : $connId total clients: " . count($this->clients));
+        $this->log->debug("Connection opend Conn ID : $connId total clients: " . count($this->clients));
     }
 
     public function onMessage(ConnectionContract $recv, $msg)


### PR DESCRIPTION
Remove IP prevention after defined time in minutes

In `.env` file we need to define below variable which means after that amount of minutes we will release that IP address for new requests.
Here value `60` is in minutes.

`SAME_IP_CONNECT_LIMIT_TIME=60`